### PR TITLE
Fix empty states in number and boolean r/w objects

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -317,29 +317,26 @@ function createTimer(vlxObjects, profile) {
         true,
         "profiles." + profile.toLowerCase()
     );
-    bool(vlxObjects,
+    swtch(vlxObjects,
         "A_CYC_" + profile.toUpperCase() + "_TIMER_ENABLED",
-        "state.enabled",
+        "switch",
         "id_text_enabled",
-        true,
         "profiles." + profile.toLowerCase()
     );
 }
 
 function createProfile(vlxObjects, profile) {
-    bool(vlxObjects,
+    swtch(vlxObjects,
         "A_CYC_" + profile.toUpperCase() + "_RH_CTRL_ENABLED",
-        "state.enabled",
+        "switch",
         "Humidity control enabled",
-        true,
         "profiles." + profile.toLowerCase()
     );
 
-    bool(vlxObjects,
+    swtch(vlxObjects,
         "A_CYC_" + profile.toUpperCase() + "_CO2_CTRL_ENABLED",
-        "state.enabled",
+        "switch",
         "CO2 control enabled",
-        true,
         "profiles." + profile.toLowerCase()
     );
 
@@ -372,12 +369,16 @@ class VlxObjectConfig {
     }
 }
 
+function swtch(objects, key, role, textId, channel) {
+    bool(objects, key, role, textId, true, channel)
+}
+
 function bool(objects, key, role, textId, writable = false, channel = null) {
-    objects.set(channel ? channel + "." + key : key, new VlxObjectConfig(key, [key], nothing, create_iobroker_object(key, role, "state", "boolean", [], writable, textId, ""), channel));
+    objects.set(channel ? channel + "." + key : key, new VlxObjectConfig(key, [key], nothing, create_iobroker_object(key, role, "state", "boolean", null, writable, textId, ""), channel));
 }
 
 function number(objects, key, role, textId, unit, writable = false, channel = null) {
-    objects.set(channel ? channel + "." + key : key, new VlxObjectConfig(key, [key], nothing, create_iobroker_object(key, role, "state", "number", [], writable, textId, unit), channel));
+    objects.set(channel ? channel + "." + key : key, new VlxObjectConfig(key, [key], nothing, create_iobroker_object(key, role, "state", "number", null, writable, textId, unit), channel));
 }
 
 function state(objects, key, role, states, textId = "", writable = false, channel = null) {


### PR DESCRIPTION

- Fix number-states with empty drop down in Objects-View
- Changed boolean states to "switch" according to iobroker guide line
- Fix missing boolean-checkbox for boolean types